### PR TITLE
Feature/relation mapping

### DIFF
--- a/src/main/java/jpa/dao/Distance.java
+++ b/src/main/java/jpa/dao/Distance.java
@@ -1,0 +1,68 @@
+package jpa.dao;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Entity
+@Table(uniqueConstraints={@UniqueConstraint(columnNames={"line_id","station_id"})})
+public class Distance extends DefaultEntity {
+    @ManyToOne
+    private Line line;
+    @ManyToOne
+    private Station station;
+    private Integer stationOrder;
+    private Integer nextDistance;
+
+    protected Distance(){}
+
+    public Distance(Line line, Station station, Integer stationOrder, Integer nextDistance) {
+        setLine(line);
+        setStation(station);
+        this.stationOrder = stationOrder;
+        this.nextDistance = nextDistance;
+    }
+
+    public String getLineName() {
+        return line.getName();
+    }
+
+    public String getStationName() {
+        return station.getName();
+    }
+
+    public void setLine(Line line) {
+        if ( this.line != null ) {
+            this.line.getDistances().remove(this);
+        }
+        line.getDistances().add(this);
+        this.line = line;
+    }
+
+    public void setStation(Station station) {
+        if ( this.station != null ) {
+            this.station.getDistances().remove(this);
+        }
+        station.getDistances().add(this);
+        this.station = station;
+    }
+
+    public Integer getStationOrder() {
+        return stationOrder;
+    }
+
+    public Integer getNextDistance() {
+        return nextDistance;
+    }
+
+    @Override
+    public String toString() {
+        return "Distance{" +
+                "line=" + line +
+                ", station=" + station +
+                ", stationOrder=" + stationOrder +
+                ", nextDistance=" + nextDistance +
+                '}';
+    }
+}

--- a/src/main/java/jpa/dao/Favorite.java
+++ b/src/main/java/jpa/dao/Favorite.java
@@ -1,12 +1,39 @@
 package jpa.dao;
 
 import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class Favorite extends DefaultEntity {
+    @ManyToOne
+    private Member member;
+    @ManyToOne
+    private Station departure;
+    @ManyToOne
+    private Station arrival;
+
     protected Favorite(){}
 
-    public Long getId() {
-        return id;
+    public Favorite(Member member, Station departure, Station arrival) {
+        this.departure = departure;
+        this.arrival = arrival;
+        setMember(member);
+    }
+
+    public void setMember(Member member) {
+        if( this.member != null ) {
+            this.member.getFavorites().remove(this);
+        }
+        member.getFavorites().add(this);
+        this.member = member;
+    }
+
+    @Override
+    public String toString() {
+        return "Favorite{" +
+                "member=" + member +
+                ", departure=" + departure +
+                ", arrival=" + arrival +
+                '}';
     }
 }

--- a/src/main/java/jpa/dao/Line.java
+++ b/src/main/java/jpa/dao/Line.java
@@ -1,13 +1,18 @@
 package jpa.dao;
 
-import org.springframework.validation.annotation.Validated;
-
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Line extends DefaultEntity {
+    @Column(unique = true)
     private String name;
     private String color;
+    @OneToMany(mappedBy = "line")
+    private List<Distance> distances = new ArrayList<>();
 
     protected Line(){}
 
@@ -22,6 +27,10 @@ public class Line extends DefaultEntity {
 
     public String getName() {
         return name;
+    }
+
+    public List<Distance> getDistances() {
+        return distances;
     }
 
     public void updateName(String name) {

--- a/src/main/java/jpa/dao/Member.java
+++ b/src/main/java/jpa/dao/Member.java
@@ -1,12 +1,19 @@
 package jpa.dao;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Member extends DefaultEntity {
     private Integer age;
+    @Column(unique = true)
     private String email;
     private String password;
+    @OneToMany(mappedBy = "member")
+    private List<Favorite> favorites = new ArrayList<>();
 
     protected Member(){}
 
@@ -14,6 +21,10 @@ public class Member extends DefaultEntity {
         this.age = age;
         this.email = email;
         this.password = password;
+    }
+
+    public List<Favorite> getFavorites() {
+        return favorites;
     }
 
     @Override

--- a/src/main/java/jpa/dao/Station.java
+++ b/src/main/java/jpa/dao/Station.java
@@ -1,14 +1,36 @@
 package jpa.dao;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Station extends DefaultEntity {
+    @Column(unique = true)
     private String name;
+    @OneToMany(mappedBy = "station")
+    private List<Distance> distances = new ArrayList<>();
 
     protected Station() {}
 
     public Station(String name) {
         this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Distance> getDistances() {
+        return distances;
+    }
+
+    @Override
+    public String toString() {
+        return "Station{" +
+                "name='" + name + '\'' +
+                '}';
     }
 }

--- a/src/main/java/jpa/repository/DistanceRepository.java
+++ b/src/main/java/jpa/repository/DistanceRepository.java
@@ -1,0 +1,15 @@
+package jpa.repository;
+
+import jpa.dao.Distance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Repository
+public interface DistanceRepository extends JpaRepository<Distance, Long> {
+    Optional<Distance> findByLine_NameAndStation_Name(String lineName, String stationName);
+    Stream<Distance> findByStationOrderGreaterThanEqualAndStationOrderLessThan(Integer departureOrder, Integer arrivalOrder);
+    Stream<Distance> findByLine_Name(String lineName);
+}

--- a/src/main/java/jpa/repository/FavoriteRepository.java
+++ b/src/main/java/jpa/repository/FavoriteRepository.java
@@ -4,6 +4,9 @@ import jpa.dao.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.stream.Stream;
+
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    Stream<Favorite> findByMember_Password(String password);
 }

--- a/src/main/java/jpa/repository/StationRepository.java
+++ b/src/main/java/jpa/repository/StationRepository.java
@@ -3,7 +3,11 @@ package jpa.repository;
 import jpa.dao.Station;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Repository
 public interface StationRepository extends JpaRepository<Station, Long> {
+    Optional<Station> findByName(String name);
 }

--- a/src/test/java/jpa/dao/DistanceTest.java
+++ b/src/test/java/jpa/dao/DistanceTest.java
@@ -20,7 +20,35 @@ public class DistanceTest {
     private StationRepository stationRepository;
     @Autowired
     private DistanceRepository distanceRepository;
-    
+
+//    private void insertTransaction(String lineName, String lineColor, String[] stationNames) {
+//        Line line = lineRepository.save(new Line(lineName, lineColor));
+//        for ( int ix = 0 ; ix < stationNames.length ; ix ++ ) {
+//            Station station = getStation(stationNames[ix]);
+//            System.out.println(station);
+//            distanceRepository.save(new Distance(line, station, ix, ix + 1));
+//        }
+//    }
+//
+//    private Station getStation(String stationName) {
+//        return stationRepository.findByName(stationName)
+//                .orElseGet(() -> stationRepository.save(new Station(stationName)));
+//    }
+//
+//    private void insertValues(String lineName, String lineColor, String[] stationNames) {
+//        FutureTask<Void> task = new FutureTask<>(() -> {
+//            insertTransaction(lineName, lineColor, stationNames);
+//            return null;
+//        });
+//
+//        try {
+//            new Thread(task).start();
+//            task.get();
+//        } catch ( ExecutionException | InterruptedException ignored ) {
+//            ignored.printStackTrace();
+//        }
+//    }
+
     private void insertValues(String lineName, String lineColor, String[] stationNames) {
         Line line = lineRepository.save(new Line(lineName, lineColor));
         for ( int ix = 0 ; ix < stationNames.length ; ix ++ ) {

--- a/src/test/java/jpa/dao/DistanceTest.java
+++ b/src/test/java/jpa/dao/DistanceTest.java
@@ -1,0 +1,79 @@
+package jpa.dao;
+
+import jpa.repository.DistanceRepository;
+import jpa.repository.LineRepository;
+import jpa.repository.StationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class DistanceTest {
+    @Autowired
+    private LineRepository lineRepository;
+    @Autowired
+    private StationRepository stationRepository;
+    @Autowired
+    private DistanceRepository distanceRepository;
+    
+    private void insertValues(String lineName, String lineColor, String[] stationNames) {
+        Line line = lineRepository.save(new Line(lineName, lineColor));
+        for ( int ix = 0 ; ix < stationNames.length ; ix ++ ) {
+            final String stationName = stationNames[ix];
+            Station station = stationRepository.findByName(stationNames[ix])
+                    .orElseGet(() -> stationRepository.save(new Station(stationName)));
+            distanceRepository.save(new Distance(line, station, ix, ix + 1));
+        }
+    }
+
+    @DisplayName("역 간 거리 구하기")
+    @Test
+    void calcDistance() {
+        insertValues("2호선", "초록", new String[]{"신도림", "대림", "구로디지털단지", "신대방", "신림"});
+
+        Distance departure = distanceRepository.findByLine_NameAndStation_Name("2호선", "대림")
+                .orElseGet(Distance::new);
+        Distance arrival = distanceRepository.findByLine_NameAndStation_Name("2호선", "신대방")
+                .orElseGet(Distance::new);
+
+        Stream<Distance> distanceStream = distanceRepository.findByStationOrderGreaterThanEqualAndStationOrderLessThan(
+                departure.getStationOrder(), arrival.getStationOrder());
+
+        Integer totalDistance = distanceStream.mapToInt(Distance::getNextDistance).sum();
+
+        assertThat(totalDistance).isEqualTo(5);
+    }
+
+    @DisplayName("환승역 찾기")
+    @Test
+    void transfer() {
+        insertValues("1호선", "파랑", new String[]{"구로", "신도림", "영등포", "신길", "대방"});
+        insertValues("2호선", "초록", new String[]{"신도림", "대림", "구로디지털단지", "신대방", "신림"});
+
+        Distance departure = distanceRepository.findByLine_NameAndStation_Name("1호선", "신길")
+                .orElseGet(Distance::new);
+
+        System.out.println(departure);
+
+        Distance arrival = distanceRepository.findByLine_NameAndStation_Name("2호선", "신대방")
+                .orElseGet(Distance::new);
+
+        System.out.println(arrival);
+
+        Stream<Distance> distanceStream = distanceRepository.findByLine_Name(arrival.getLineName());
+
+        Distance expected = distanceStream.filter(distance -> {
+            System.out.println(distance);
+            return distanceRepository.findByLine_NameAndStation_Name(departure.getLineName(), distance.getStationName()).isPresent();
+        })
+                .findFirst()
+                .orElseGet(Distance::new);
+
+        assertThat(expected.getStationName()).isEqualTo("신도림");
+    }
+}

--- a/src/test/java/jpa/dao/FavoriteTest.java
+++ b/src/test/java/jpa/dao/FavoriteTest.java
@@ -1,23 +1,41 @@
 package jpa.dao;
 
 import jpa.repository.FavoriteRepository;
+import jpa.repository.MemberRepository;
+import jpa.repository.StationRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class FavoriteTest {
     @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StationRepository stationRepository;
+    @Autowired
     private FavoriteRepository favoriteRepository;
 
+    @DisplayName("Member의 Favorite 조회")
     @Test
-    void findById() {
-        Favorite favorite = new Favorite();
-        Favorite source = favoriteRepository.save(favorite);
-        Favorite expected = favoriteRepository.findById(source.getId())
-                .orElseGet(Favorite::new);
-        assertThat(source.getId()).isEqualTo(expected.getId());
+    void register() {
+        Member member = memberRepository.save(new Member(20, "email@naver.com", "password"));
+        Station departure = stationRepository.save(new Station("신도림"));
+        Station arrival = stationRepository.save(new Station("영등포"));
+
+        favoriteRepository.save(new Favorite(member, departure, arrival));
+
+        Station arrival2 = stationRepository.save(new Station("서울"));
+
+        favoriteRepository.save(new Favorite(member, departure, arrival2));
+
+        Stream<Favorite> favoriteStream = favoriteRepository.findByMember_Password("password");
+
+        assertThat(favoriteStream.count()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
2단계 - 연관 관계 매핑 과제 제출합니다.

JPA랑 Transactional 관련해서 이것저것 알아보다보니 과제 제출이 좀 늦었습니다 ㅎㅎ..

근데 이제 어느정도 이해가 됐다고 생각했는데, 한 가지 이해가 안되는 상황을 발견해서요, 마지막 커밋에 질문용 주석 추가한 것 보시면 내용이 있는데, 제가 궁금한 부분은 아래 내용입니다.

주석을 풀고 "환승역 찾기" 테스트를 시도하면 실패하게 되는데, 이유는

org.hibernate.LazyInitializationException:` failed to lazily initialize a collection of role

이렇습니다. 메세지 내용을 봐도 검색을 해봐도 아무래도 지연로딩 시점에 발생하는 예외 같은데, 새로운 스레드를 만들고 같은 역이 있을 때, 정확히는 stationRepository.findByName의 결과값이 존재 할 때 예외가 발생 합니다. 제 생각에는 어차피 다른 영속성 컨텍스트를 사용하니 그냥 새로 select를 해서 가져올 수 있을거라 생각했는데 이런식으로 접근했을 경우 어떤 영향이 있어서 지연 로딩에 실패하게 되는지 알 수 있을까요 ? ㅜ