### PR TITLE
Feature/mapping refactoring

### DIFF
--- a/src/main/java/jpa/dao/Distance.java
+++ b/src/main/java/jpa/dao/Distance.java
@@ -1,16 +1,13 @@
 package jpa.dao;
 
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
 
 @Entity
 @Table(uniqueConstraints={@UniqueConstraint(columnNames={"line_id","station_id"})})
 public class Distance extends DefaultEntity {
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Line line;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Station station;
     private Integer stationOrder;
     private Integer nextDistance;

--- a/src/main/java/jpa/dao/Favorite.java
+++ b/src/main/java/jpa/dao/Favorite.java
@@ -1,15 +1,16 @@
 package jpa.dao;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 
 @Entity
 public class Favorite extends DefaultEntity {
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Station departure;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Station arrival;
 
     protected Favorite(){}

--- a/src/test/java/jpa/dao/DistanceTest.java
+++ b/src/test/java/jpa/dao/DistanceTest.java
@@ -7,12 +7,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
+@SpringBootTest
+@Transactional
 public class DistanceTest {
     @Autowired
     private LineRepository lineRepository;
@@ -20,44 +26,34 @@ public class DistanceTest {
     private StationRepository stationRepository;
     @Autowired
     private DistanceRepository distanceRepository;
+    @Autowired
+    private InsertWorker insertWorker;
 
-//    private void insertTransaction(String lineName, String lineColor, String[] stationNames) {
+    private void insertValues(String lineName, String lineColor, String[] stationNames) {
+        System.out.println("insertValues() : " + TransactionSynchronizationManager.getCurrentTransactionName());
+        FutureTask<Void> task = new FutureTask<>(() -> {
+            System.out.println("new Thread() : " + TransactionSynchronizationManager.getCurrentTransactionName());
+            insertWorker.insertTransaction(lineName, lineColor, stationNames);
+            return null;
+        });
+
+        try {
+            new Thread(task).start();
+            task.get();
+        } catch ( ExecutionException | InterruptedException ignored ) {
+            ignored.printStackTrace();
+        }
+    }
+
+//    private void insertValues(String lineName, String lineColor, String[] stationNames) {
 //        Line line = lineRepository.save(new Line(lineName, lineColor));
 //        for ( int ix = 0 ; ix < stationNames.length ; ix ++ ) {
-//            Station station = getStation(stationNames[ix]);
-//            System.out.println(station);
+//            final String stationName = stationNames[ix];
+//            Station station = stationRepository.findByName(stationNames[ix])
+//                    .orElseGet(() -> stationRepository.save(new Station(stationName)));
 //            distanceRepository.save(new Distance(line, station, ix, ix + 1));
 //        }
 //    }
-//
-//    private Station getStation(String stationName) {
-//        return stationRepository.findByName(stationName)
-//                .orElseGet(() -> stationRepository.save(new Station(stationName)));
-//    }
-//
-//    private void insertValues(String lineName, String lineColor, String[] stationNames) {
-//        FutureTask<Void> task = new FutureTask<>(() -> {
-//            insertTransaction(lineName, lineColor, stationNames);
-//            return null;
-//        });
-//
-//        try {
-//            new Thread(task).start();
-//            task.get();
-//        } catch ( ExecutionException | InterruptedException ignored ) {
-//            ignored.printStackTrace();
-//        }
-//    }
-
-    private void insertValues(String lineName, String lineColor, String[] stationNames) {
-        Line line = lineRepository.save(new Line(lineName, lineColor));
-        for ( int ix = 0 ; ix < stationNames.length ; ix ++ ) {
-            final String stationName = stationNames[ix];
-            Station station = stationRepository.findByName(stationNames[ix])
-                    .orElseGet(() -> stationRepository.save(new Station(stationName)));
-            distanceRepository.save(new Distance(line, station, ix, ix + 1));
-        }
-    }
 
     @DisplayName("역 간 거리 구하기")
     @Test
@@ -80,6 +76,7 @@ public class DistanceTest {
     @DisplayName("환승역 찾기")
     @Test
     void transfer() {
+        System.out.println("tranfer() : " + TransactionSynchronizationManager.getCurrentTransactionName());
         insertValues("1호선", "파랑", new String[]{"구로", "신도림", "영등포", "신길", "대방"});
         insertValues("2호선", "초록", new String[]{"신도림", "대림", "구로디지털단지", "신대방", "신림"});
 

--- a/src/test/java/jpa/dao/InsertWorker.java
+++ b/src/test/java/jpa/dao/InsertWorker.java
@@ -1,0 +1,36 @@
+package jpa.dao;
+
+import jpa.repository.DistanceRepository;
+import jpa.repository.LineRepository;
+import jpa.repository.StationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+@Transactional
+public class InsertWorker {
+    @Autowired
+    private LineRepository lineRepository;
+    @Autowired
+    private StationRepository stationRepository;
+    @Autowired
+    private DistanceRepository distanceRepository;
+
+    public void insertTransaction(String lineName, String lineColor, String[] stationNames) {
+        System.out.println("insertTransaction() : " + TransactionSynchronizationManager.getCurrentTransactionName());
+        Line line = lineRepository.save(new Line(lineName, lineColor));
+        for ( int ix = 0 ; ix < stationNames.length ; ix ++ ) {
+            Station station = getStation(stationNames[ix]);
+            System.out.println(station);
+            distanceRepository.save(new Distance(line, station, ix, ix + 1));
+        }
+    }
+
+    public Station getStation(String stationName) {
+        System.out.println("getStation() : " + TransactionSynchronizationManager.getCurrentTransactionName());
+        return stationRepository.findByName(stationName)
+                .orElseGet(() -> stationRepository.save(new Station(stationName)));
+    }
+}


### PR DESCRIPTION
3단계 - 다대다 연관 관계 리팩터링 과제 제출합니다.

2단계 그림에 역간 거리가 표시돼있길래 .. 본의 아니게 과제를 몰아서 해버린게 됐네요.. 😓 

하지만 개인적으로는 엔티티 관계 맵핑보다는 영속성 컨텍스트와 Transactional의 연관관계쪽이 좀 더 어렵고 중요한 부분이다 생각했어서 굉장히 유익한 시간 보냈습니다.

한 트랜잭션에서 처리가 돼야 한다는 건 알고 있었는데, 피드백 주신거 보자마자 머리가 띵 해서 조금 관점을 달리 해서 찾아 봤습니다. 트랜잭션이 적용 됐을거라 생각했던 부분이 적용이 안 돼서 생긴 문제더라구요.

바깥에 트랜잭션이 없으니 save()가 단일 트랜잭션으로 동작하게되고, save()에서의 트랜잭션이 끝나니 밑에서 가져다 쓸 때 lazy-loading에 문제가 생겼던 .. Trasactional이 프록시 기반으로 적용이 된다는 걸 간과했었는데, 이번에 삽질 하면서 JPA 뿐만 아니라 Spring전체적으로도 많이 고민할 수 있는 시간 가졌고 많이 배웠습니다. 깨달음을 얻고 가슴이 벅차올라서 결과 확인했던 코드는 그대로 커밋해버렸어요 😄 

피드백 주셨던 FetchType에 대해서는 딱히 코드상으로는 크게 표현 할 부분이 없어서 어노테이션 말곤 건드리지 않았습니다. 대신 주관적인 생각은 여기에 남겨두겠습니다. Lazy-Loading 적용으로 인한 쿼리 변경은 확인을 했고, 불필요 할 수 있는 join과 의도치 않았을 수 있는 추가적인 select 구문 수행 이슈 관련해서, 저도 디폴트로 LAZY 타입을 지정 해 두는게 맞다고 생각되네요. 웜업 한다고 생각하면 문제가 없을 수도 있지만, 어차피 재사용이 돼 봐야 1차캐시 범위 내에서 재사용이 될 것이니 그렇다고 하면 웜업을 해놓기에 적합한 대상은 아니라고 생각합니다. 어차피 조인 없이 단일테이블 쿼리면 인덱스도 걸려 있겠다, 조회에 큰 부하가 없을테니, 쓸 때 가져오는게 맞다고 생각합니다. 어노테이션 디폴트가 왜 EAGER인지는 모르겠지만 ..

이번 과제 진행하면서 제가 좀 익숙치 않은 부분이라 개인적인 공부시간이 좀 길었었는데, 덕분에 너무 뿌듯하고 유익한 시간 보냈어요. 요 며칠간 잠은 잘 못잤어도 즐거웠습니다 😃 
뭔가 이해가 된듯된듯 안된거같아서 답답한 와중에 마지막 한 조각, 힌트로 채워주셔서 감사드립니다. 덕분에 기분 굉장히 상쾌해요 👍