### PR TITLE
Step3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation("com.google.guava:guava:30.1-jre")
     runtimeOnly 'com.h2database:h2:1.4.196'
-//    runtimeOnly 'mysql:mysql-connector-java'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/test/java/jpa/repository/FavoriteTest.java
+++ b/src/test/java/jpa/repository/FavoriteTest.java
@@ -1,0 +1,44 @@
+package jpa.repository;
+
+import jpa.favorite.Favorite;
+import jpa.favorite.FavoriteRepository;
+import jpa.member.Member;
+import jpa.member.MemberRepository;
+import jpa.station.Station;
+import jpa.station.StationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+public class FavoriteTest {
+
+    @Autowired
+    private MemberRepository members;
+
+    @Autowired
+    private StationRepository stations;
+
+    @Autowired
+    private FavoriteRepository favorites;
+
+    @Test
+    void save() {
+        Station fromStation = stations.save(new Station("이대역"));
+        Station toStation = stations.save(new Station("신촌역"));
+        Member member = members.save(new Member(32, "suahnn@gmail.com", "1234"));
+
+        Favorite expected = new Favorite(member, fromStation, toStation);
+        Favorite actual = favorites.save(expected);
+
+        assertAll(
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getMember()).isEqualTo(expected.getMember()),
+                () -> assertThat(actual.getFromStation().getId()).isEqualTo(expected.getFromStation().getId()),
+                () -> assertThat(actual.getToStation().getId()).isEqualTo(expected.getToStation().getId())
+        );
+    }
+}


### PR DESCRIPTION
`@ManyToMany` 를 사용하면 관계테이블에 필드를 추가로 넣어주지 못하는 것으로 알고 있는데
지하철역과 노선의 관계를 구성할 때 `distance` 필드를 넣으려면 `@ManyToMany` 를 사용하지 말고
현재 구현한 `@OneToMany` 와 `@ManyToOne` 구조가 맞아보이는데요.

꼭 `@ManyToMany` 를 사용해서 리팩터링 해야하나요??

우선 이전 피드백 주신 부분 수정해서 풀리 올려봅니다.