### PR TITLE
3단계 - 다대다 연관 관계 리팩터링 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@
 - Line <> Station 양방향 관계 설정
 - Favorite <> Member 다대일 관계 설정
 - Favorite <> Station 다대일 관계 설정
+
+## 3단계 - 다대다 연관관계 리팩토링
+- 다대다를 일대다, 다대일로 리팩토링

--- a/src/main/java/jpa/domain/line/Line.java
+++ b/src/main/java/jpa/domain/line/Line.java
@@ -5,12 +5,10 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
 
 import jpa.domain.BaseEntity;
-import jpa.domain.station.Station;
+import jpa.domain.linestation.LineStation;
 
 @Entity
 public class Line extends BaseEntity {
@@ -19,8 +17,8 @@ public class Line extends BaseEntity {
 
 	private String name;
 
-	@ManyToMany
-	private List<Station> stations = new ArrayList<>();
+	@OneToMany(mappedBy = "line")
+	private List<LineStation> lineStations = new ArrayList<>();
 
 	protected Line() {
 	}
@@ -28,12 +26,6 @@ public class Line extends BaseEntity {
 	public Line(String color, String name) {
 		this.color = color;
 		this.name = name;
-	}
-
-	public Line(String color, String name, List<Station> stations) {
-		this.color = color;
-		this.name = name;
-		this.stations = stations;
 	}
 
 	public String getColor() {
@@ -52,7 +44,7 @@ public class Line extends BaseEntity {
 		this.name = name;
 	}
 
-	public List<Station> getStations() {
-		return stations;
+	public List<LineStation> getLineStations() {
+		return lineStations;
 	}
 }

--- a/src/main/java/jpa/domain/linestation/LineStation.java
+++ b/src/main/java/jpa/domain/linestation/LineStation.java
@@ -1,0 +1,67 @@
+package jpa.domain.linestation;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+import jpa.domain.BaseEntity;
+import jpa.domain.line.Line;
+import jpa.domain.station.Station;
+
+@Entity
+public class LineStation extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Line line;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Station station;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	private Station previousStation;
+
+	private int distance;
+
+	protected LineStation() {
+	}
+
+	public LineStation(Line line, Station station, Station previousStation, int distance) {
+		this.line = line;
+		this.station = station;
+		this.previousStation = previousStation;
+		this.distance = distance;
+	}
+
+	public Line getLine() {
+		return line;
+	}
+
+	public void setLine(Line line) {
+		this.line = line;
+	}
+
+	public Station getStation() {
+		return station;
+	}
+
+	public void setStation(Station station) {
+		this.station = station;
+	}
+
+	public int getDistance() {
+		return distance;
+	}
+
+	public void setDistance(int distance) {
+		this.distance = distance;
+	}
+
+	public Station getPreviousStation() {
+		return previousStation;
+	}
+
+	public void setPreviousStation(Station previousStation) {
+		this.previousStation = previousStation;
+	}
+}

--- a/src/main/java/jpa/domain/linestation/LineStationRepository.java
+++ b/src/main/java/jpa/domain/linestation/LineStationRepository.java
@@ -1,0 +1,6 @@
+package jpa.domain.linestation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineStationRepository extends JpaRepository<LineStation, Long> {
+}

--- a/src/main/java/jpa/domain/station/Station.java
+++ b/src/main/java/jpa/domain/station/Station.java
@@ -5,20 +5,18 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
 
 import jpa.domain.BaseEntity;
-import jpa.domain.line.Line;
+import jpa.domain.linestation.LineStation;
 
 @Entity
 public class Station extends BaseEntity {
 	@Column(unique = true)
 	private String name;
 
-	@ManyToMany(mappedBy = "stations")
-	private List<Line> lines = new ArrayList<>();
+	@OneToMany(mappedBy = "station")
+	private List<LineStation> lineStations = new ArrayList<>();
 
 	protected Station() {
 	}
@@ -35,7 +33,7 @@ public class Station extends BaseEntity {
 		this.name = name;
 	}
 
-	public List<Line> getLines() {
-		return lines;
+	public List<LineStation> getLineStations() {
+		return lineStations;
 	}
 }

--- a/src/test/java/jpa/domain/line/LineRepositoryTest.java
+++ b/src/test/java/jpa/domain/line/LineRepositoryTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import jpa.domain.linestation.LineStation;
+import jpa.domain.linestation.LineStationRepository;
 import jpa.domain.station.Station;
 import jpa.domain.station.StationRepository;
 
@@ -23,6 +25,9 @@ class LineRepositoryTest {
 
 	@Autowired
 	private StationRepository stations;
+
+	@Autowired
+	private LineStationRepository lineStations;
 
 	@DisplayName("Line save 테스트")
 	@Test
@@ -98,33 +103,5 @@ class LineRepositoryTest {
 
 		// then
 		assertThat(lines.findById(lineId).isPresent()).isFalse();
-	}
-
-	@Test
-	public void saveWithStation() {
-		// given
-		int expected = 2;
-		Station stationOne = new Station("강남역");
-		Station stationTwo = new Station("잠실역");
-
-		List<Station> stationList = new ArrayList<>();
-		stationList.add(stationOne);
-		stationList.add(stationTwo);
-
-		Line line = new Line("green", "2호선", stationList);
-
-		// when
-		stations.save(stationOne);
-		stations.save(stationTwo);
-		Long lineId = lines.save(line).getId();
-
-		// then
-		Line findLine = lines
-			.findById(lineId).orElseThrow(() -> new IllegalArgumentException("아이디에 해당하는 데이터가 없습니다."));
-		List<Station> findStation = findLine.getStations();
-		for (Station s : findStation) {
-			System.out.println("station name = " + s.getName());
-		}
-		assertThat(expected).isEqualTo(findStation.size());
 	}
 }

--- a/src/test/java/jpa/domain/linestation/LineStationRepositoryTest.java
+++ b/src/test/java/jpa/domain/linestation/LineStationRepositoryTest.java
@@ -1,0 +1,62 @@
+package jpa.domain.linestation;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import jpa.domain.line.Line;
+import jpa.domain.line.LineRepository;
+import jpa.domain.station.Station;
+import jpa.domain.station.StationRepository;
+
+@DataJpaTest
+class LineStationRepositoryTest {
+	@Autowired
+	LineStationRepository lineStations;
+
+	@Autowired
+	LineRepository lines;
+
+	@Autowired
+	StationRepository stations;
+
+	@Test
+	public void findLineStationWithLineAndStation() {
+		// given
+		String expectedPreviousStationName = "서초역";
+		String expectedStationName = "강남역";
+		String expectedLineColor = "green";
+		String expectedLineName = "2호선";
+		Line line = new Line(expectedLineColor, expectedLineName);
+		Station previousStation = new Station(expectedPreviousStationName);
+		Station station = new Station(expectedStationName);
+
+		// when
+		lines.save(line);
+		stations.save(station);
+		stations.save(previousStation);
+
+		LineStation previousLineStation = new LineStation(line, previousStation, null, 0);
+		LineStation lineStation = new LineStation(line, station, previousStation, 20);
+		Long previousLineStationId = lineStations.save(previousLineStation).getId();
+		Long lineStationId = lineStations.save(lineStation).getId();
+
+		// then
+		LineStation findPreviousLineStation = lineStations.findById(previousLineStationId)
+			.orElseThrow(() -> new IllegalArgumentException("아이디에 해당하는 데이터가 없습니다."));
+		LineStation findLineStation = lineStations.findById(lineStationId)
+			.orElseThrow(() -> new IllegalArgumentException("아이디에 해당하는 데이터가 없습니다."));
+		assertThat(expectedPreviousStationName).isEqualTo(findPreviousLineStation.getStation().getName());
+		assertThat(expectedStationName).isEqualTo(findLineStation.getStation().getName());
+		assertThat(expectedLineColor).isEqualTo(findPreviousLineStation.getLine().getColor());
+		assertThat(expectedLineName).isEqualTo(findPreviousLineStation.getLine().getName());
+		assertThat(expectedLineColor).isEqualTo(findLineStation.getLine().getColor());
+		assertThat(expectedLineName).isEqualTo(findLineStation.getLine().getName());
+	}
+
+}

--- a/src/test/java/jpa/domain/linestation/LineStationRepositoryTest.java
+++ b/src/test/java/jpa/domain/linestation/LineStationRepositoryTest.java
@@ -32,6 +32,7 @@ class LineStationRepositoryTest {
 		String expectedStationName = "강남역";
 		String expectedLineColor = "green";
 		String expectedLineName = "2호선";
+		int expectedDistance = 20;
 		Line line = new Line(expectedLineColor, expectedLineName);
 		Station previousStation = new Station(expectedPreviousStationName);
 		Station station = new Station(expectedStationName);
@@ -57,6 +58,39 @@ class LineStationRepositoryTest {
 		assertThat(expectedLineName).isEqualTo(findPreviousLineStation.getLine().getName());
 		assertThat(expectedLineColor).isEqualTo(findLineStation.getLine().getColor());
 		assertThat(expectedLineName).isEqualTo(findLineStation.getLine().getName());
+		assertThat(expectedDistance).isEqualTo(findLineStation.getDistance());
 	}
 
+	@Test
+	public void updateLineStation() {
+		// given
+		String expectedStationName = "교대역";
+		int expectedDistance = 30;
+		Line line = new Line("green", "2호선");
+		Station previousStation = new Station("서초역");
+		Station station = new Station("강남역");
+
+		lines.save(line);
+		stations.save(station);
+		stations.save(previousStation);
+		lineStations.save(new LineStation(line, previousStation, null, 0));
+		Long lineStationId = lineStations.save(new LineStation(line, station, previousStation, 50)).getId();
+
+		// when
+		Station newStation = new Station("교대역");
+		stations.save(newStation);
+		LineStation newLineStation = new LineStation(line, newStation, previousStation, 20);
+		lineStations.save(newLineStation);
+
+		LineStation lineStation = lineStations.findById(lineStationId)
+			.orElseThrow(() -> new IllegalArgumentException("아이디에 해당하는 데이터가 없습니다."));
+		lineStation.setPreviousStation(newStation);
+		lineStation.setDistance(30);
+
+		// then
+		LineStation findLineStation = lineStations.findById(lineStationId)
+			.orElseThrow(() -> new IllegalArgumentException("아이디에 해당하는 데이터가 없습니다."));
+		assertThat(expectedStationName).isEqualTo(findLineStation.getPreviousStation().getName());
+		assertThat(expectedDistance).isEqualTo(findLineStation.getDistance());
+	}
 }


### PR DESCRIPTION
안녕하세요.

다대다 연관 관계 리팩터링 PR합니다.

LineStation을 엔티티로 격상하여, 다대다를 일대다, 다대일로 바꾸고, 이전 역 정보와 거리 정보는 LineStation이 갖도록 수정하였습니다.

매번 꼼꼼한 리뷰 감사합니다.